### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/CharpFYI/1806fe37-2a93-4fd9-820a-5b45551ef53d/254a5781-8653-43f4-9b1b-61d97502d02b/_apis/work/boardbadge/9278f4a0-b737-4cc7-8d57-632db26ff8a7)](https://dev.azure.com/CharpFYI/1806fe37-2a93-4fd9-820a-5b45551ef53d/_boards/board/t/254a5781-8653-43f4-9b1b-61d97502d02b/Microsoft.RequirementCategory)
 # ShoppingList
 Example Shopping List application implemented using the Power Platform. PowerApps canvas app.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/CharpFYI/1806fe37-2a93-4fd9-820a-5b45551ef53d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.